### PR TITLE
Reflect that v1.2 is no longer a canary version

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,7 +8,7 @@
 
 # Introduction
 
-> **Note** - This plugin works only with [**Tailwind CSS Canary (or v1.2)**](https://github.com/tailwindcss/tailwindcss/tree/v1.2.0-canary.2). You can install `tailwindcss@canary` with NPM.
+> **Note** - This plugin works only with [**Tailwind CSS v1.2**](https://github.com/tailwindcss/tailwindcss/tree/v1.2.0) and above.
 
 `tailwindcss-scroll-snap` adds [CSS Scroll Snap](https://css-tricks.com/practical-css-scroll-snapping/) utilities to Tailwind CSS.
 


### PR DESCRIPTION
In the README,  it says that Tailwind CSS v1.2 is a canary version. This PR updates the copy to reflect that v1.2 is no longer canary.